### PR TITLE
perf: 用户提问含有敏感词，新增相关日志输出（userid及用户提问内容）

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,6 +49,7 @@ func Start() {
 		// 去除问题的前后空格
 		msgObj.Text.Content = strings.TrimSpace(msgObj.Text.Content)
 		if public.JudgeSensitiveWord(msgObj.Text.Content) {
+			logger.Info(fmt.Sprintf("🙋 %s提问的问题中包含敏感词汇，userid：%#v，消息: %#v", msgObj.SenderNick, msgObj.SenderStaffId, msgObj.Text.Content))
 			_, err = msgObj.ReplyToDingtalk(string(dingbot.MARKDOWN), "**🤷 抱歉，您提问的问题中包含敏感词汇，请审核自己的对话内容之后再进行！**")
 			if err != nil {
 				logger.Warning(fmt.Errorf("send message error: %v", err))


### PR DESCRIPTION
**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [x] 我已阅读并理解[贡献者指南](https://github.com/eryajf/chatgpt-dingtalk/blob/main/CONTRIBUTING.md)。
- [x] 我已检查没有与此请求重复的拉取请求。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭拉取请求。