### PR TITLE
fix: 修复 session_timeout 配置项不生效的bug，优化相关缓存逻辑，同时余额、查对话功能权限优化

### DIFF
--- a/pkg/cache/user_base.go
+++ b/pkg/cache/user_base.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"time"
 
+	"github.com/eryajf/chatgpt-dingtalk/public"
 	"github.com/patrickmn/go-cache"
 )
 

--- a/pkg/cache/user_base.go
+++ b/pkg/cache/user_base.go
@@ -36,5 +36,5 @@ type UserService struct {
 
 // NewUserService 创建新的业务层
 func NewUserService() UserServiceInterface {
-	return &UserService{cache: cache.New(time.Second*public.Config.SessionTimeout, time.Hour*1)}
+	return &UserService{cache: cache.New(public.Config.SessionTimeout, time.Hour*1)}
 }

--- a/pkg/cache/user_base.go
+++ b/pkg/cache/user_base.go
@@ -34,9 +34,10 @@ type UserService struct {
 	cache *cache.Cache
 }
 
+var Config *config.Configuration
+
 // NewUserService 创建新的业务层
 func NewUserService() UserServiceInterface {
-	var Config *config.Configuration
 	// 加载配置
 	Config = config.LoadConfig()
 	return &UserService{cache: cache.New(Config.SessionTimeout, time.Hour*1)}

--- a/pkg/cache/user_base.go
+++ b/pkg/cache/user_base.go
@@ -35,5 +35,5 @@ type UserService struct {
 
 // NewUserService 创建新的业务层
 func NewUserService() UserServiceInterface {
-	return &UserService{cache: cache.New(time.Hour*2, time.Hour*5)}
+	return &UserService{cache: cache.New(time.Second*public.Config.SessionTimeout, time.Hour*1)}
 }

--- a/pkg/cache/user_base.go
+++ b/pkg/cache/user_base.go
@@ -3,7 +3,7 @@ package cache
 import (
 	"time"
 
-	"github.com/eryajf/chatgpt-dingtalk/public"
+	"github.com/eryajf/chatgpt-dingtalk/config"
 	"github.com/patrickmn/go-cache"
 )
 
@@ -36,5 +36,8 @@ type UserService struct {
 
 // NewUserService 创建新的业务层
 func NewUserService() UserServiceInterface {
-	return &UserService{cache: cache.New(public.Config.SessionTimeout, time.Hour*1)}
+	var Config *config.Configuration
+	// 加载配置
+	Config = config.LoadConfig()
+	return &UserService{cache: cache.New(Config.SessionTimeout, time.Hour*1)}
 }

--- a/pkg/chatgpt/chatgpt.go
+++ b/pkg/chatgpt/chatgpt.go
@@ -28,11 +28,7 @@ func New(userId string) *ChatGPT {
 	var ctx context.Context
 	var cancel func()
 
-	if public.Config.SessionTimeout == 0 {
-		ctx, cancel = context.WithCancel(context.Background())
-	} else {
-		ctx, cancel = context.WithTimeout(context.Background(), public.Config.SessionTimeout)
-	}
+	ctx, cancel = context.WithTimeout(context.Background(), 600)
 	timeOutChan := make(chan struct{}, 1)
 	go func() {
 		<-ctx.Done()

--- a/pkg/process/process_request.go
+++ b/pkg/process/process_request.go
@@ -45,10 +45,6 @@ func ProcessRequest(rmsg *dingbot.ReceiveMsg) error {
 				logger.Warning(fmt.Errorf("send message error: %v", err))
 			}
 		case "模板":
-			// 清空用户对话上下文
-			public.UserService.ClearUserSessionContext(rmsg.GetSenderIdentifier())
-			// 清空用户对话的答案ID
-			public.UserService.ClearAnswerID(rmsg.SenderNick, rmsg.GetChatTitle())
 			var title string
 			for _, v := range *public.Prompt {
 				title = title + v.Title + " | "

--- a/pkg/process/process_request.go
+++ b/pkg/process/process_request.go
@@ -3,6 +3,7 @@ package process
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/eryajf/chatgpt-dingtalk/pkg/db"
 	"github.com/eryajf/chatgpt-dingtalk/pkg/dingbot"
@@ -15,16 +16,20 @@ import (
 func ProcessRequest(rmsg *dingbot.ReceiveMsg) error {
 	if CheckRequestTimes(rmsg) {
 		content := strings.TrimSpace(rmsg.Text.Content)
+		timeoutStr := ""
+		if content != public.Config.DefaultMode {
+			timeoutStr = fmt.Sprintf("\n\n>%s 后将恢复默认聊天模式：%s", FormatTimeDuation(public.Config.SessionTimeout), public.Config.DefaultMode)
+		}
 		switch content {
 		case "单聊":
 			public.UserService.SetUserMode(rmsg.GetSenderIdentifier(), content)
-			_, err := rmsg.ReplyToDingtalk(string(dingbot.MARKDOWN), fmt.Sprintf("**[Concentrate] 现在进入与 %s 的单聊模式**", rmsg.SenderNick))
+			_, err := rmsg.ReplyToDingtalk(string(dingbot.MARKDOWN), fmt.Sprintf("**[Concentrate] 现在进入与 %s 的单聊模式**%s", rmsg.SenderNick, timeoutStr))
 			if err != nil {
 				logger.Warning(fmt.Errorf("send message error: %v", err))
 			}
 		case "串聊":
 			public.UserService.SetUserMode(rmsg.GetSenderIdentifier(), content)
-			_, err := rmsg.ReplyToDingtalk(string(dingbot.MARKDOWN), fmt.Sprintf("**[Concentrate] 现在进入与 %s 的串聊模式**", rmsg.SenderNick))
+			_, err := rmsg.ReplyToDingtalk(string(dingbot.MARKDOWN), fmt.Sprintf("**[Concentrate] 现在进入与 %s 的串聊模式**%s", rmsg.SenderNick, timeoutStr))
 			if err != nil {
 				logger.Warning(fmt.Errorf("send message error: %v", err))
 			}
@@ -40,6 +45,10 @@ func ProcessRequest(rmsg *dingbot.ReceiveMsg) error {
 				logger.Warning(fmt.Errorf("send message error: %v", err))
 			}
 		case "模板":
+			// 清空用户对话上下文
+			public.UserService.ClearUserSessionContext(rmsg.GetSenderIdentifier())
+			// 清空用户对话的答案ID
+			public.UserService.ClearAnswerID(rmsg.SenderNick, rmsg.GetChatTitle())
 			var title string
 			for _, v := range *public.Prompt {
 				title = title + v.Title + " | "
@@ -62,25 +71,28 @@ func ProcessRequest(rmsg *dingbot.ReceiveMsg) error {
 				logger.Warning(fmt.Errorf("send message error: %v", err))
 			}
 		case "余额":
-			cacheMsg := public.UserService.GetUserMode("system_balance")
-			if cacheMsg == "" {
-				rst, err := public.GetBalance()
-				if err != nil {
-					logger.Warning(fmt.Errorf("get balance error: %v", err))
-					return err
+			if public.JudgeAdminUsers(rmsg.SenderStaffId) {
+				cacheMsg := public.UserService.GetUserMode("system_balance")
+				if cacheMsg == "" {
+					rst, err := public.GetBalance()
+					if err != nil {
+						logger.Warning(fmt.Errorf("get balance error: %v", err))
+						return err
+					}
+					cacheMsg = rst
 				}
-				cacheMsg = rst
-			}
-			// cacheMsg := "官方暂时改写了余额接口，因此暂不提供查询余额功能！2023-04-03"
-			_, err := rmsg.ReplyToDingtalk(string(dingbot.TEXT), cacheMsg)
-			if err != nil {
-				logger.Warning(fmt.Errorf("send message error: %v", err))
+				_, err := rmsg.ReplyToDingtalk(string(dingbot.TEXT), cacheMsg)
+				if err != nil {
+					logger.Warning(fmt.Errorf("send message error: %v", err))
+				}
 			}
 		case "查对话":
-			msg := "使用如下指令进行查询:\n\n---\n\n**#查对话 username:张三**\n\n---\n\n需要注意格式必须严格与上边一致，否则将会查询失败\n\n只有程序系统管理员有权限查询，即config.yml中的admin_users指定的人员。"
-			_, err := rmsg.ReplyToDingtalk(string(dingbot.MARKDOWN), msg)
-			if err != nil {
-				logger.Warning(fmt.Errorf("send message error: %v", err))
+			if public.JudgeAdminUsers(rmsg.SenderStaffId) {
+				msg := "使用如下指令进行查询:\n\n---\n\n**#查对话 username:张三**\n\n---\n\n需要注意格式必须严格与上边一致，否则将会查询失败\n\n只有程序系统管理员有权限查询，即config.yml中的admin_users指定的人员。"
+				_, err := rmsg.ReplyToDingtalk(string(dingbot.MARKDOWN), msg)
+				if err != nil {
+					logger.Warning(fmt.Errorf("send message error: %v", err))
+				}
 			}
 		default:
 			if public.FirstCheck(rmsg) {
@@ -222,6 +234,19 @@ func Do(mode string, rmsg *dingbot.ReceiveMsg) error {
 
 	}
 	return nil
+}
+// FormatTimeDuation 格式化时间
+// 主要提示单聊/群聊切换时多久后恢复默认聊天模式
+func FormatTimeDuation(duration time.Duration) string {
+	minutes := int64(duration.Minutes())
+	seconds := int64(duration.Seconds()) - minutes*60
+	timeoutStr := ""
+	if seconds == 0 {
+		timeoutStr = fmt.Sprintf("%d分钟", minutes)
+	} else {
+		timeoutStr = fmt.Sprintf("%d分%d秒", minutes, seconds)
+	}
+	return timeoutStr
 }
 
 // CheckRequestTimes 分析处理请求逻辑


### PR DESCRIPTION
**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [x] 我已阅读并理解[贡献者指南](https://github.com/eryajf/chatgpt-dingtalk/blob/main/CONTRIBUTING.md)。
- [x] 我已检查没有与此请求重复的拉取请求。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭拉取请求。

本次更新内容如下：

1. 主要修复session_timeout 配置项（会话超时时间,默认600秒,在会话时间内所有发送给机器人的信息会作为上下文）不生效的bug，优化相关缓存逻辑
2. 余额、查对话功能仅管理员可用（outgoing下无法使用），非管理员发起指令，机器人将无任何回应

修改相关说明如下：

1. chatgpt.go文件中原来是从session_timeout配置项取值来设置与chatgpt的连接超时，这里设置成600默认，能满足需要。无需再从配置项获取
2. user_base.go文件中原来并未从session_timeout配置项取值，而是设置的默认2小时失效，5小时清空失效缓存。这里修改为从配置项中获取，修复bug，同时将缓存清理时间改为1小时，可一定程度上降低内存占用
3. process_request.go文件中新增 FormatTimeDuation 方法来处理时间的格式化展示
4. process_request.go文件中新增 单群/聊 切换时的提示：如切换至与默认聊天模式一致则不提示超时时间，从而提醒用户
5. process_request.go文件中新增 余额、查对话功能仅管理员可用的逻辑