### PR TITLE
fix: 修复钉钉Markdown消息内不支持html代码显示的bug，对html标签进行转义

### DIFF
--- a/pkg/process/process_request.go
+++ b/pkg/process/process_request.go
@@ -232,6 +232,7 @@ func Do(mode string, rmsg *dingbot.ReceiveMsg) error {
 	}
 	return nil
 }
+
 // FormatTimeDuation 格式化时间
 // 主要提示单聊/群聊切换时多久后恢复默认聊天模式
 func FormatTimeDuation(duration time.Duration) string {
@@ -247,8 +248,8 @@ func FormatTimeDuation(duration time.Duration) string {
 }
 
 // FormatMarkdown 格式化Markdown
-// 主要修复ChatGPT返回多行代码块，钉钉会将代码块中的#当作Markdown语法里的标题来处理，这里进行下转义
-// 如果Markdown格式内存在html，钉钉无法显示Markdown格式内的html代码，这里将Markdown中的html标签转义
+// 主要修复ChatGPT返回多行代码块，钉钉会将代码块中的#当作Markdown语法里的标题来处理，进行转义；如果Markdown格式内存在html，将Markdown中的html标签转义
+// 代码块缩进问题暂无法解决，因不管是四个空格，还是Tab，在钉钉上均会顶格显示，建议复制代码后用IDE进行代码格式化，针对缩进严格的语言，例如Python，不确定的建议手机端查看下代码块的缩进
 func FormatMarkdown(md string) string {
 	lines := strings.Split(md, "\n")
 	codeblock := false

--- a/pkg/process/process_request.go
+++ b/pkg/process/process_request.go
@@ -2,6 +2,7 @@ package process
 
 import (
 	"fmt"
+	"html"
 	"strings"
 	"time"
 
@@ -247,14 +248,22 @@ func FormatTimeDuation(duration time.Duration) string {
 
 // FormatMarkdown 格式化Markdown
 // 主要修复ChatGPT返回多行代码块，钉钉会将代码块中的#当作Markdown语法里的标题来处理，这里进行下转义
+// 如果Markdown格式内存在html，钉钉无法显示Markdown格式内的html代码，这里将Markdown中的html标签转义
 func FormatMarkdown(md string) string {
 	lines := strings.Split(md, "\n")
 	codeblock := false
 	for i, line := range lines {
 		if strings.HasPrefix(line, "```") {
 			codeblock = !codeblock
-		} else if codeblock && strings.HasPrefix(line, "#") {
-			lines[i] = "\\" + lines[i]
+		}
+		if codeblock {
+			lines[i] = strings.ReplaceAll(line, "#", "\\#")
+		}
+	}
+	// 如果Markdown内存在html，将Markdown中的html标签转义
+	if strings.Contains(md, "<") {
+		for i, line := range lines {
+			lines[i] = html.EscapeString(line)
 		}
 	}
 	return strings.Join(lines, "\n")


### PR DESCRIPTION
**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [x] 我已阅读并理解[贡献者指南](https://github.com/eryajf/chatgpt-dingtalk/blob/main/CONTRIBUTING.md)。
- [x] 我已检查没有与此请求重复的拉取请求。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭拉取请求。

此问题的根本原因是钉钉pc端在Markdown消息内会将html代码进行渲染（哪怕html代码是在代码块内也会进行渲染，从而导致无法正常显示相关代码），而手机端无法显示（显示空白）含有html代码的Markdown消息，本质上是钉钉的bug。
代码块缩进问题暂无法解决，因不管是四个空格，还是Tab，在钉钉上均会顶格显示，建议复制代码后用IDE进行代码格式化，针对缩进严格的语言，例如Python，不确定的建议手机端查看下代码块的缩进。
经验证，经过转义后，html代码显示问题已修复（无论是代码块内，还是代码块外均无显示问题），如下图所示：

<img width="792" alt="image" src="https://user-images.githubusercontent.com/29793346/232247318-b221df24-d510-4992-a7ed-85e983c08dd2.png">

<img width="792" alt="image" src="https://user-images.githubusercontent.com/29793346/232247400-9c3159ed-226c-45f4-b03f-d5e2a554f311.png">

