### PR TITLE
fix: 将docker-compose的outgoing配置留空

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       # 群ID，可在群组中 @机器人 群ID 来查看日志获取，例如日志会输出：[🙋 企业内部机器人 在『测试』群的ConversationID为: "cidrabcdefgh1234567890AAAAA"]，获取后可填写该参数并重启程序
       # 如果不想支持outgoing机器人功能，这里可以随意设置一个内部群组，例如：cidrabcdefgh1234567890AAAAA；或随意一个字符串，例如：disabled
       # 建议该功能默认关闭：除非你必须要用到outgoing机器人
-      ALLOW_OUTGOING_GROUPS: "disabled"   # 哪些普通群（使用outgoing机器人）可以进行对话，如果留空，则表示允许所有群组，如果要限制，则列表中写群ID（ConversationID）
+      ALLOW_OUTGOING_GROUPS: ""   # 哪些普通群（使用outgoing机器人）可以进行对话，如果留空，则表示允许所有群组，如果要限制，则列表中写群ID（ConversationID）
       # 以下 ALLOW_USERS、DENY_USERS、VIP_USERS、ADMIN_USERS 配置中填写的是用户的userid
       # 比如 ["1301691029702722","1301691029702733"]，这个信息需要在钉钉管理后台的通讯录当中获取：https://oa.dingtalk.com/contacts.htm#/contacts
       # 哪些用户可以进行对话，如果留空，则表示允许所有用户，如果要限制，则列表中写用户的userid


### PR DESCRIPTION
**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [x] 我已阅读并理解[贡献者指南](https://github.com/eryajf/chatgpt-dingtalk/blob/main/CONTRIBUTING.md)。
- [x] 我已检查没有与此请求重复的拉取请求。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭拉取请求。