### PR TITLE
fix: html escape

### DIFF
--- a/pkg/process/process_request.go
+++ b/pkg/process/process_request.go
@@ -253,20 +253,19 @@ func FormatTimeDuation(duration time.Duration) string {
 func FormatMarkdown(md string) string {
 	lines := strings.Split(md, "\n")
 	codeblock := false
+	existHtml := strings.Contains(md, "<")
+
 	for i, line := range lines {
 		if strings.HasPrefix(line, "```") {
 			codeblock = !codeblock
 		}
 		if codeblock {
 			lines[i] = strings.ReplaceAll(line, "#", "\\#")
-		}
-	}
-	// 如果Markdown内存在html，将Markdown中的html标签转义
-	if strings.Contains(md, "<") {
-		for i, line := range lines {
+		} else if existHtml {
 			lines[i] = html.EscapeString(line)
 		}
 	}
+
 	return strings.Join(lines, "\n")
 }
 


### PR DESCRIPTION
**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [x] 我已阅读并理解[贡献者指南](https://github.com/eryajf/chatgpt-dingtalk/blob/main/CONTRIBUTING.md)。
- [x] 我已检查没有与此请求重复的拉取请求。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭拉取请求。

currently, when escaping the html in markdown, the html tags in the code block are also escaped.

![image](https://user-images.githubusercontent.com/38101022/235294794-b4719f3c-92c6-49ae-9e0e-ea8213368af8.png)

hope it can skip escaping html tags in code blocks, like this

![image](https://user-images.githubusercontent.com/38101022/235294843-6e554c7a-dfd4-4504-aa20-e2a8afac1bb5.png)
