### PR TITLE
fix: 当回复消息类型为markdown时,at功能不生效

### DIFF
--- a/pkg/dingbot/dingbot.go
+++ b/pkg/dingbot/dingbot.go
@@ -97,6 +97,9 @@ func (r ReceiveMsg) ReplyToDingtalk(msgType, msg string) (statuscode int, err er
 	case string(TEXT):
 		msgtmp = &TextMessage{Text: &Text{Content: msg}, MsgType: TEXT, At: &At{AtUserIds: []string{atUser}}}
 	case string(MARKDOWN):
+		if atUser != "" {
+			msg = fmt.Sprintf("%s\n\n@%s", msg, atUser)
+		}
 		msgtmp = &MarkDownMessage{MsgType: MARKDOWN, At: &At{AtUserIds: []string{atUser}}, MarkDown: &MarkDown{Title: "Markdown Type", Text: msg}}
 	default:
 		msgtmp = &TextMessage{Text: &Text{Content: msg}, MsgType: TEXT, At: &At{AtUserIds: []string{atUser}}}


### PR DESCRIPTION
参考官方文档: https://open.dingtalk.com/document/orgapp/custom-robots-send-group-messages

消息类型为 markdown 时, 需要在content里添加@人的userid。


**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [* ] 我已阅读并理解[贡献者指南](https://github.com/eryajf/chatgpt-dingtalk/blob/main/CONTRIBUTING.md)。
- [ *] 我已检查没有与此请求重复的拉取请求。
- [ *] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [ *] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭拉取请求。