### PR TITLE
fix: ack dingtalk callbacks before processing

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,10 +89,8 @@ func (r *ChatReceiver) OnChatBotMessageReceived(ctx context.Context, data *chatb
 		RobotCode:                 r.clientId, // 使用 clientId 作为 RobotCode
 		Msgtype:                   dingbot.MsgType(data.Msgtype),
 	}
-	clientId := r.clientId
-	var c gin.Context
-	c.Set(public.DingTalkClientIdKeyName, clientId)
-	DoRequest(msgObj, &c)
+	requestCtx := context.WithValue(context.Background(), public.DingTalkClientIdKeyName, r.clientId)
+	go DoRequest(requestCtx, msgObj)
 
 	return []byte(""), nil
 }
@@ -105,7 +103,16 @@ func StartHttp() {
 		if err != nil {
 			return
 		}
-		DoRequest(msgObj, c)
+		clientId, checkOk := public.CheckRequestWithCredentials(c.GetHeader("timestamp"), c.GetHeader("sign"))
+		if !checkOk {
+			logger.Warning("该请求不合法，可能是其他企业或者未经允许的应用调用所致，请知悉！")
+			c.Status(http.StatusUnauthorized)
+			return
+		}
+
+		requestCtx := context.WithValue(context.Background(), public.DingTalkClientIdKeyName, clientId)
+		go DoRequest(requestCtx, msgObj)
+		c.Status(http.StatusOK)
 	})
 	// 解析生成后的图片
 	app.GET("/images/:filename", func(c *gin.Context) {
@@ -166,17 +173,7 @@ func StartHttp() {
 	logger.Info("Server exiting!")
 }
 
-func DoRequest(msgObj dingbot.ReceiveMsg, c *gin.Context) {
-	// 先校验回调是否合法
-	if public.Config.RunMode == "http" {
-		clientId, checkOk := public.CheckRequestWithCredentials(c.GetHeader("timestamp"), c.GetHeader("sign"))
-		if !checkOk {
-			logger.Warning("该请求不合法，可能是其他企业或者未经允许的应用调用所致，请知悉！")
-			return
-		}
-		// 通过 context 传递 OAuth ClientID，用于后续流程中调用钉钉OpenAPI
-		c.Set(public.DingTalkClientIdKeyName, clientId)
-	}
+func DoRequest(ctx context.Context, msgObj dingbot.ReceiveMsg) {
 	// 再校验回调参数是否有价值
 	if msgObj.Text.Content == "" || msgObj.ChatbotUserID == "" {
 		logger.Warning("从钉钉回调过来的内容为空，根据过往的经验，或许重新创建一下机器人，能解决这个问题")
@@ -246,7 +243,7 @@ func DoRequest(msgObj dingbot.ReceiveMsg, c *gin.Context) {
 		// 除去帮助之外的逻辑分流在这里处理
 		switch {
 		case strings.HasPrefix(msgObj.Text.Content, "#图片"):
-			err := process.ImageGenerate(c, &msgObj)
+			err := process.ImageGenerate(ctx, &msgObj)
 			if err != nil {
 				logger.Warning(fmt.Errorf("process request: %v", err))
 				return


### PR DESCRIPTION
## Summary

- 将钉钉回调的耗时处理切到 goroutine，先返回 HTTP 200/stream ack。
- HTTP 模式仍先完成签名校验，非法请求返回 401。
- 通过 context 继续传递 DingTalk OAuth ClientID，供图片生成等后续 OpenAPI 调用使用。

## Motivation

部分 LLM/图片生成请求耗时较长，如果钉钉回调等待处理完成后才返回，容易触发钉钉侧重试。先 ack 后异步处理可以避免重复回调，同时保持原有业务逻辑继续执行。

## Validation

- `go test ./...`
  - 当前失败在既有 `public` 包 `CheckRequestWithCredentials` 测试；本 PR 只改 `main.go`。

**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [x] 我已阅读并理解[贡献者指南](https://github.com/eryajf/chatgpt-dingtalk/blob/main/CONTRIBUTING.md)。
- [x] 我已检查没有与此请求重复的拉取请求。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭拉取请求。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request authentication error handling with appropriate HTTP status codes for validation failures.

* **Performance**
  * Request processing now runs asynchronously, enabling faster response times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->